### PR TITLE
fix: fix the correct url for Merriam Webster Learners Dictionary

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -126,7 +126,7 @@ export default class Helper {
 			"MerriamWebsterL":{
 				"func":"MerriamWebsterL",
 				"title":"Merriam Webster Learners Dictionary",
-				"url":"https://www.britannica.com/dictionary/"
+				"url":"https://www.merriam-webster.com/dictionary/"
 			},
 			"CollinsCobuildDict":{
 				"func":"CollinsCobuildDict",


### PR DESCRIPTION

![](https://github.com/pMan/Lookup-for-chrome/assets/73936909/a3ee009f-13c0-4391-8214-7816cc8b1848)

As the figure shows, the URL is incorrectly linked to Britannica Dictionary.